### PR TITLE
Pin dependency babel-register to version 6.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.16.3",
+    "babel-register": "6.22.0",
     "coveralls": "~2.11.4",
     "eslint": "^3.4.0",
     "eslint-config-simplifield": "^4.1.1",


### PR DESCRIPTION
This Pull Request updates dependency babel-register from version ^6.16.3 to 6.22.0

