### PR TITLE
Pin dependency babel-preset-es2015 to version 6.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",
-    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2015": "6.22.0",
     "babel-register": "^6.16.3",
     "coveralls": "~2.11.4",
     "eslint": "^3.4.0",


### PR DESCRIPTION
This Pull Request updates dependency babel-preset-es2015 from version ^6.14.0 to 6.22.0

