### PR TITLE
Pin dependency babel-cli to version 6.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/SimpliField/sf-preferences/issues"
   },
   "devDependencies": {
-    "babel-cli": "^6.16.0",
+    "babel-cli": "6.22.2",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.16.3",
     "coveralls": "~2.11.4",


### PR DESCRIPTION
This Pull Request updates dependency babel-cli from version ^6.16.0 to 6.22.2

