### PR TITLE
Pin dependency coveralls to version 2.11.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-cli": "^6.16.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.16.3",
-    "coveralls": "~2.11.4",
+    "coveralls": "2.11.15",
     "eslint": "^3.4.0",
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "^1.0.0-alpha.2",


### PR DESCRIPTION
This Pull Request updates dependency coveralls from version ~2.11.4 to 2.11.15

