### PR TITLE
Pin dependency eslint-config-simplifield to version 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-register": "^6.16.3",
     "coveralls": "~2.11.4",
     "eslint": "^3.4.0",
-    "eslint-config-simplifield": "^4.1.1",
+    "eslint-config-simplifield": "4.4.0",
     "istanbul": "^1.0.0-alpha.2",
     "jsdoc-to-markdown": "^2.0.0",
     "mocha": "~3.2.0",


### PR DESCRIPTION
This Pull Request updates dependency eslint-config-simplifield from version ^4.1.1 to 4.4.0

