### PR TITLE
Pin dependency mocha to version 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "^1.0.0-alpha.2",
     "jsdoc-to-markdown": "^2.0.0",
-    "mocha": "~3.2.0",
+    "mocha": "3.2.0",
     "mocha-lcov-reporter": "^1.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This Pull Request updates dependency mocha from version ~3.2.0 to 3.2.0

