### PR TITLE
Pin dependency eslint to version 3.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.16.3",
     "coveralls": "~2.11.4",
-    "eslint": "^3.4.0",
+    "eslint": "3.14.0",
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "^1.0.0-alpha.2",
     "jsdoc-to-markdown": "^2.0.0",


### PR DESCRIPTION
This Pull Request updates dependency eslint from version ^3.4.0 to 3.14.0

