### PR TITLE
Pin dependency jsdoc-to-markdown to version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^3.4.0",
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "^1.0.0-alpha.2",
-    "jsdoc-to-markdown": "^2.0.0",
+    "jsdoc-to-markdown": "2.0.1",
     "mocha": "~3.2.0",
     "mocha-lcov-reporter": "^1.0.0"
   },


### PR DESCRIPTION
This Pull Request updates dependency jsdoc-to-markdown from version ^2.0.0 to 2.0.1

