### PR TITLE
[Chore] Pin dependency mocha-lcov-reporter to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "istanbul": "1.1.0-alpha.1",
     "jsdoc-to-markdown": "^2.0.0",
     "mocha": "3.2.0",
-    "mocha-lcov-reporter": "^1.0.0"
+    "mocha-lcov-reporter": "1.2.0"
   },
   "dependencies": {
     "yerror": "1.0.2"


### PR DESCRIPTION
This Pull Request update dependency mocha-lcov-reporter from version ^1.0.0 to 1.2.0

