### PR TITLE
[Chore] Pin dependency babel-preset-es2015 to version 6.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "babel-cli": "6.22.2",
-    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2015": "6.22.0",
     "babel-register": "6.22.0",
     "coveralls": "~2.11.4",
     "eslint": "3.14.1",


### PR DESCRIPTION
This Pull Request update dependency babel-preset-es2015 from version ^6.14.0 to 6.22.0

