### PR TITLE
[Chore] Pin dependency coveralls to version 2.11.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-cli": "6.22.2",
     "babel-preset-es2015": "6.22.0",
     "babel-register": "6.22.0",
-    "coveralls": "~2.11.4",
+    "coveralls": "2.11.15",
     "eslint": "3.14.1",
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "1.1.0-alpha.1",


### PR DESCRIPTION
This Pull Request update dependency coveralls from version ~2.11.4 to 2.11.15

