### PR TITLE
[Chore] Update dependency eslint to version 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "6.22.0",
     "babel-register": "6.22.0",
     "coveralls": "2.11.16",
-    "eslint": "3.14.1",
+    "eslint": "3.15.0",
     "eslint-config-simplifield": "4.4.0",
     "istanbul": "1.1.0-alpha.1",
     "jsdoc-to-markdown": "2.0.1",


### PR DESCRIPTION
This Pull Request update dependency eslint from version 3.14.1 to 3.15.0

### Changelog

#### 3.15.0 / 2017-02-03

  * 3.15.0
  * Build: package.json and changelog update for 3.15.0
  * Fix: &#x60;no-extra-parens&#x60; incorrect precedence (fixes [#7978](https://github.com/eslint/eslint/issues/7978)) ([#7999](https://github.com/eslint/eslint/issues/7999))
  * Fix: no-var should fix ForStatement.init ([#7993](https://github.com/eslint/eslint/issues/7993))
    * Fix: no-var should fix ForStatement.init
    * Chore: add tests
  * Upgrade: Espree v3.4.0 ([#8019](https://github.com/eslint/eslint/issues/8019))
  * Docs: update README.md for team ([#8016](https://github.com/eslint/eslint/issues/8016))
  * Chore: enable template-tag-spacing on ESLint codebase ([#8005](https://github.com/eslint/eslint/issues/8005))
    This enables template-tag-spacing for dogfooding. There are no existing violations with the default &quot;never&quot; option, and 37 existing violations with the &quot;always&quot; option.
  * Docs: Fix typo in object-curly-newline.md ([#8002](https://github.com/eslint/eslint/issues/8002))
    It looks like the curly braces got turned into square brackets between the incorrect and correct code examples.
  * Docs: Fix misleading section in brace-style documentation ([#7996](https://github.com/eslint/eslint/issues/7996))
    It looks like this section was added when the brace-style rule only supported the 1tbs option, and the section hasn&#x27;t been updated since then.
  * Chore: avoid unnecessary feature detection for Symbol ([#7992](https://github.com/eslint/eslint/issues/7992))
    The Symbol global exists in all Node versions supported by eslint.
  * Chore: fix no-else-return lint error (refs [#7986](https://github.com/eslint/eslint/issues/7986)) ([#7994](https://github.com/eslint/eslint/issues/7994))
  * Chore: enable no-else-return on ESLint codebase ([#7986](https://github.com/eslint/eslint/issues/7986))
    * Chore: enable no-else-return on ESLint codebase
    * Move a comment after a brace
  * Update: add ignoreRestSiblings option to no-unused-vars ([#7968](https://github.com/eslint/eslint/issues/7968))
    Update: no-unused-vars to account for rest property omissions
    Update docs
    Update: use RestProperty and only check last property
    Temp
    temp
    temp
    Use parent type
  * Chore: enable no-unneeded-ternary on ESLint codebase ([#7987](https://github.com/eslint/eslint/issues/7987))
  * Update: ensure operator-assignment handles exponentiation operators ([#7970](https://github.com/eslint/eslint/issues/7970))
  * Update: add &quot;variables&quot; option to no-use-before-define (fixes [#7111](https://github.com/eslint/eslint/issues/7111)) ([#7948](https://github.com/eslint/eslint/issues/7948))
    * Update: add &quot;variables&quot; option to no-use-before-define (fixes [#7111](https://github.com/eslint/eslint/issues/7111))
    * Clarify the default behavior
  * New: &#x60;template-tag-spacing&#x60; rule (fixes [#7631](https://github.com/eslint/eslint/issues/7631)) ([#7913](https://github.com/eslint/eslint/issues/7913))
    * New: &#x60;template-tag-spacing&#x60; rule (fixes [#7631](https://github.com/eslint/eslint/issues/7631))
    * Check template tags wrapped in parens
    * Change rule category to &quot;Stylistic Issues&quot;
    * Rephrase rule documentation intro
    Rewrote the intro do be more descriptive about tagged template literals.
    Also includes a &quot;Further Reading&quot; section.
    * Update docs to better explain the rule concept
    * Add tests for tags with comments
    * Documentation nits
    * Adjust template tag autofixing behaviour when there&#x27;s comments present