### PR TITLE
[Chore] Update dependency yerror to version 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "mocha-lcov-reporter": "1.2.0"
   },
   "dependencies": {
-    "yerror": "1.0.2"
+    "yerror": "2.0.0"
   }
 }


### PR DESCRIPTION
This Pull Request update dependency yerror from version 1.0.2 to 2.0.0

### Changelog

#### 2.0.0 / 2017-02-06

  * 2.0.0
  * Merge pull request [#4](https://github.com/SimpliField/yerror/issues/4) from SimpliField/fix/node7
    Fix/node7
  * chore(package): require node &gt;&#x3D; 6
  * Fixing Node7 error
  * docs(badges): improve display
  * Merge pull request [#2](https://github.com/SimpliField/yerror/issues/2) from SimpliField/greenkeeper/remove-node-0.10
    👻😱 Node.js 0.10 is unmaintained 😱👻
  * chore(travis): remove node 0.x &amp; add 6
  * chore: drop support for Node.js 0.10
    BREAKING CHANGE: This module no longer supports Node.js 0.10
  * Merge pull request [#1](https://github.com/SimpliField/yerror/issues/1) from SimpliField/greenkeeper-update-all
    Update all dependencies 🌴
  * chore(package): update dependencies
    https://greenkeeper.io/
  * Various cleanups