### PR TITLE
[Chore] Update dependency coveralls to version 2.11.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-cli": "6.22.2",
     "babel-preset-es2015": "6.22.0",
     "babel-register": "6.22.0",
-    "coveralls": "2.11.15",
+    "coveralls": "2.11.16",
     "eslint": "3.14.1",
     "eslint-config-simplifield": "4.4.0",
     "istanbul": "1.1.0-alpha.1",


### PR DESCRIPTION
This Pull Request update dependency coveralls from version 2.11.15 to 2.11.16

### Changelog

#### 2.11.16 / 2017-02-05

  * version bump
  * Merge branch &#x27;master&#x27; of github.com:nickmerwin/node-coveralls
  * removed codeship badge
  * Merge pull request [#152](https://github.com/nickmerwin/node-coveralls/issues/152) from ndaidong/master
    Update outdated dependencies
  * Merge pull request [#147](https://github.com/nickmerwin/node-coveralls/issues/147) from hyperlink/update-request-dep
    Fix node-uuid deprecation by updating request dependency
  * Merge pull request [#154](https://github.com/nickmerwin/node-coveralls/issues/154) from a0viedo/patch-1
    don&#x27;t hardcode minor version
  * Merge pull request [#142](https://github.com/nickmerwin/node-coveralls/issues/142) from Hirse/feature/travis-pr
    Get PR number from TRAVIS
  * Merge pull request [#155](https://github.com/nickmerwin/node-coveralls/issues/155) from kasperlewau/master
    Reenabling Drone
  * reenable drone
  * don&#x27;t hardcode minor version
    It&#x27;s making run the CI with older versions of Node releases and more importantly with branches that don&#x27;t receive security patches.
  * Update outdate dependencies
    - Update request, nyc, istanbul, mocha to the latest version
    - Ref nickmerwin/node-coveralls[#149](https://github.com/nickmerwin/node-coveralls/issues/149)
  * Fix node-uuid deprecation by updating request dependency